### PR TITLE
Fix compiler warning triggered by deprecated syntax in swift 4.1.

### DIFF
--- a/App Store Receipt Checker/CMSDecoder.swift
+++ b/App Store Receipt Checker/CMSDecoder.swift
@@ -38,7 +38,7 @@ public extension CMSDecoder { // MARK: functions
     public func decryptedContent() throws -> [UInt8] {
         var dataOptional: CFData?
         try CMSDecoderCopyContent(self, &dataOptional) | { throw Errors.cannotGetDecryptedData(status: $0) }
-        let data: Data! = dataOptional as Data!
+        let data = dataOptional! as Data
         return data.withUnsafeBytes { Array(UnsafeBufferPointer(start: $0, count: data.count)) }
     }
 }


### PR DESCRIPTION
Xcode 9.4.1 shows a warning on the line of code modified in this request, see diff. Nothing critical, just an annoying message from our best friend Xcode.