### PR TITLE
Use string constants provided by IOKit

### DIFF
--- a/App Store Receipt Checker/Store Receipts/Receipt.swift
+++ b/App Store Receipt Checker/Store Receipts/Receipt.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 import CommonCrypto
-import IOKit
+import IOKit.network
 
 public struct Receipt {
     // MARK: properties


### PR DESCRIPTION
I’ve read the article about MAC address too and was about to make a pull request when I noticed that you already have it fixed. Thank you for keeping this updated.

Funny thing, my PR was going to be semantically equivalent to your commit, line by line. The only difference is using IOKit constants.
