### PR TITLE
Require macOS 10.12 in SwiftPM too

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "AppStoreReceiptChecker",
     platforms: [
-        .macOS(.v10_11)
+        .macOS(.v10_12)
     ],
     products: [
         .library(name: "AppStoreReceiptChecker", targets: ["AppStoreReceiptChecker"]),


### PR DESCRIPTION
Fix: Swift Package failed to build since it required 10.11